### PR TITLE
refactor(game): Make Game a singleton class

### DIFF
--- a/dev/car.ts
+++ b/dev/car.ts
@@ -7,13 +7,13 @@ class Car {
     private speed:number = 0
     private game:Game
     public check:number
-        
-    constructor(game:Game) {
 
+    constructor() {
+        // Because Game is now a singleton, you can easily get the instance via a static method
+        this.game = Game.getInstance()
         this.element = document.createElement("car")
         let foreground = document.getElementsByTagName("foreground")[0]
         foreground.appendChild(this.element)
-        this.game = game
         this.posx = 100
         this.posy = 750
         this.check = this.game.generateRandom()

--- a/dev/game.ts
+++ b/dev/game.ts
@@ -2,11 +2,35 @@ class Game {
     
     protected car:Car
 
-    constructor() {
-        this.car = new Car(this)
+    private static instance:Game
+
+    /**
+     * The constructor should be private if this class is a singleton.
+     * This prevents other classes of creating a new Game instance.
+     */
+    private constructor() {}
+
+    /**
+     * Because the class could still be 'in construction' when the constructor of the Car class is running,
+     * the Car constructor will call Game.getInstance() which will then create another Game instance.
+     * This creates an infinite loop. Thats why we have to call another method after the constructor is done.
+     */
+    public initialize() {
+        this.car = new Car()
         this.gameLoop()
         this.generateRandom()
         this.showKey()
+    }
+
+    /**
+     * Game should be a singleton class,
+     * because there will always only be 1 instance of Game.
+     */
+    public static getInstance() {
+        if (!this.instance) {            
+            this.instance = new Game()
+        }
+        return this.instance
     }
 
     public generateRandom():number{
@@ -28,5 +52,7 @@ class Game {
 } 
 
 window.addEventListener("load", () => {
-    new Game();
+    // Create a Game instance and when that's done, call the initialize method.
+    const g = Game.getInstance()
+    g.initialize()
 });


### PR DESCRIPTION
I've changed the Game class to be a singleton class. This makes sure other classes can't by accident (or intentionally) create another Game instance. Also, there's now no need anymore to add the Game instance as a parameter to access it in other classes. Just call Game.getInstance() to get the current game.

I've left comments above every method I've made / changed :)